### PR TITLE
chore: bump version to 0.0.6 in package.json and update release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
     release:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write # Allow actions to push to the repository
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "time-master",
     "type": "module",
-    "version": "0.0.4",
+    "version": "0.0.6",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Updated version in package.json from 0.0.4 to 0.0.6.
- Added write permissions for contents in the release workflow to allow actions to push to the repository.